### PR TITLE
Adding audit meta issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/design-audit-meta.md
+++ b/.github/ISSUE_TEMPLATE/design-audit-meta.md
@@ -1,0 +1,46 @@
+---
+name: [Design audit] Release version
+label: audit, meta
+about: Template for meta issue for UI/UX audit of a release
+---
+
+# How to audit
+
+- Please describe in detail the specific features or areas of the app that you want the auditor to go through.
+- **Assign yourself** to either app (should not be one that you've worked on for the release).
+- If you find obvious bugs, please report them to the respective teams as bugs in the Kibana repo. **Remember to create as bug issues with the appropiate release label**
+- Collect all the polish feedback in a separate [Design audit](https://github.com/elastic/observability-design/issues/new?assignees=&labels=&template=design-audit.md).
+- The responsible designer will go through the suggested enhancements and create issues for the engineering team.
+- Even if there are no major changes to some of the apps, please do an audit anyhow. There might have been changes to shared components that are now affecting views that otherwise didn't have changes.
+
+# Audits
+
+## Cross Observability
+
+🖐️ _Add assignee_
+
+- Observability overview
+
+## Metrics
+
+🖐️ _Add assignee_
+
+## Logs
+
+🖐️ _Add assignee_
+
+## APM
+
+🖐️ _Add assignee_
+
+## Uptime/Synthetics
+
+🖐️ _Add assignee_
+
+## User Experience
+
+🖐️ _Add assignee_
+
+## Fleet
+
+🖐️ _Add assignee_


### PR DESCRIPTION
I typically have to create these by copy and pasting from previous audit meta issue, so thought to create a meta issue template for this.