### PR TITLE
Assign default label that will add a ping to the design alias

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,5 @@
+---
+issues:
+  opened:
+    add:
+      - design


### PR DESCRIPTION
### What

Use bot to manage label assignment when a github issue is created.
Use bot to manage adding comments when the `design` label is added.

